### PR TITLE
[FP-22] Tooltip Component

### DIFF
--- a/src/components/tooltip/Tooltip.test.tsx
+++ b/src/components/tooltip/Tooltip.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from '@testing-library/react';
+import { Tooltip } from './Tootltip';
+
+describe('Tooltips render correctly', () => {
+  beforeAll(() => {
+    render(
+      <div>
+        <Tooltip type="warning" />
+        <Tooltip type="error" />
+        <Tooltip label="custom" />
+      </div>
+    );
+  });
+
+  it('Renders all different types of tooltips', () => {
+    expect(screen.getByTestId('success')).toBeDefined();
+    expect(screen.getByTestId('warning')).toBeDefined();
+    expect(screen.getByTestId('error')).toBeDefined();
+  });
+
+  it('Renders custom tooltips', () => {
+    expect(screen.queryByText('custom')).toBeDefined();
+  });
+});

--- a/src/components/tooltip/Tootltip.scss
+++ b/src/components/tooltip/Tootltip.scss
@@ -1,0 +1,22 @@
+.tip{
+    min-width: 110px;
+    width: auto;
+    border-radius: 8px;
+    padding: 2px 10px;
+    color: white;
+    text-transform: uppercase;
+    font-size: small;
+    margin: 5px;
+}
+
+.red{
+    background-color:tomato;
+}
+
+.warn{
+    background-color:gold;
+}
+
+.succ{
+    background-color: seagreen;
+}

--- a/src/components/tooltip/Tootltip.scss
+++ b/src/components/tooltip/Tootltip.scss
@@ -7,16 +7,18 @@
     text-transform: uppercase;
     font-size: small;
     margin: 5px;
-}
-
-.red{
+    @at-root .error{
     background-color:tomato;
-}
+    border: none;
+    }
 
-.warn{
-    background-color:gold;
-}
+    @at-root .warning{
+        background-color:gold;
+    }
 
-.succ{
-    background-color: seagreen;
+    @at-root .success{
+        background-color: seagreen;
+    }
+
 }
+    

--- a/src/components/tooltip/Tootltip.scss
+++ b/src/components/tooltip/Tootltip.scss
@@ -7,9 +7,10 @@
     text-transform: uppercase;
     font-size: small;
     margin: 5px;
+
     &.error{
-    background-color:tomato;
-    border: none;
+        background-color:tomato;
+        border: none;
     }
 
     &.warning{

--- a/src/components/tooltip/Tootltip.scss
+++ b/src/components/tooltip/Tootltip.scss
@@ -7,16 +7,16 @@
     text-transform: uppercase;
     font-size: small;
     margin: 5px;
-    @at-root .error{
+    &.error{
     background-color:tomato;
     border: none;
     }
 
-    @at-root .warning{
+    &.warning{
         background-color:gold;
     }
 
-    @at-root .success{
+    &.success{
         background-color: seagreen;
     }
 

--- a/src/components/tooltip/Tootltip.tsx
+++ b/src/components/tooltip/Tootltip.tsx
@@ -2,22 +2,13 @@ import React from 'react';
 import './Tootltip.scss';
 
 interface Props {
-  type?: 'warn' | 'success' | 'error' | undefined;
+  type?: 'warning' | 'success' | 'error' | undefined;
   label?: string | undefined;
 }
 
-export const Tooltip = ({ type, label }: Props) => {
-  switch (type) {
-    case 'error':
-      return <div className="tip red">{label || 'Error'} </div>;
-    case 'warn':
-      return <div className="tip warn">{label || 'Warning'} </div>;
-    case 'success':
-      return <div className="tip succ">{label || 'Success'} </div>;
-    default:
-      return <div className="tip succ">{label || 'Success'} </div>;
-  }
-};
+export const Tooltip = ({ type, label }: Props) => (
+  <div className={`tip ${type}`}> {label || type} </div>
+);
 
 Tooltip.defaultProps = {
   type: 'success',

--- a/src/components/tooltip/Tootltip.tsx
+++ b/src/components/tooltip/Tootltip.tsx
@@ -8,8 +8,7 @@ interface Props {
 
 export const Tooltip = ({ type, label }: Props) => (
   <div data-testid={type} className={`tip ${type}`}>
-    {' '}
-    {label || type}{' '}
+    {label || type}
   </div>
 );
 

--- a/src/components/tooltip/Tootltip.tsx
+++ b/src/components/tooltip/Tootltip.tsx
@@ -7,7 +7,10 @@ interface Props {
 }
 
 export const Tooltip = ({ type, label }: Props) => (
-  <div className={`tip ${type}`}> {label || type} </div>
+  <div data-testid={type} className={`tip ${type}`}>
+    {' '}
+    {label || type}{' '}
+  </div>
 );
 
 Tooltip.defaultProps = {

--- a/src/components/tooltip/Tootltip.tsx
+++ b/src/components/tooltip/Tootltip.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import './Tootltip.scss';
+
+interface Props {
+  type?: 'warn' | 'success' | 'error' | undefined;
+  label?: string | undefined;
+}
+
+export const Tooltip = ({ type, label }: Props) => {
+  switch (type) {
+    case 'error':
+      return <div className="tip red">{label || 'Error'} </div>;
+    case 'warn':
+      return <div className="tip warn">{label || 'Warning'} </div>;
+    case 'success':
+      return <div className="tip succ">{label || 'Success'} </div>;
+    default:
+      return <div className="tip succ">{label || 'Success'} </div>;
+  }
+};
+
+Tooltip.defaultProps = {
+  type: 'success',
+  label: undefined,
+};

--- a/src/pages/Login/Login.tsx
+++ b/src/pages/Login/Login.tsx
@@ -47,6 +47,7 @@ export const Login = () => {
           If you are already a member you can login with <br />
           your email address and password.
         </p>
+
         <form
           onSubmit={handleSubmit(onSubmit)}
           data-testid="loginForm"

--- a/src/pages/Login/Login.tsx
+++ b/src/pages/Login/Login.tsx
@@ -47,7 +47,6 @@ export const Login = () => {
           If you are already a member you can login with <br />
           your email address and password.
         </p>
-
         <form
           onSubmit={handleSubmit(onSubmit)}
           data-testid="loginForm"


### PR DESCRIPTION
### Description

Added a tooltip component. Can be used with two props:
 - Type: ("success":default , "warn", "error") Changes the type of tooltip,
 - Label: (string) Changes the content of the tooltip label.
 
![image](https://user-images.githubusercontent.com/93210838/190830059-df71ce32-9210-40ad-b4e7-58e7391ffdbf.png)

### Testing Checklist

- [ ] Test cases have been added/updated
- [x] Tested locally in browser (at least one other than Chrome)
- [x] All tests pass

### What JIRA Ticket(s) does this PR address?

- [FP-22](https://cd95.atlassian.net/browse/FP-22)
